### PR TITLE
feat: v1.3 — add Motorola and EMUI variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.3.0] - 2026-03-23
+
+### Added
+- **Motorola variant** — installs to `/oem/media/` (separate OEM partition used by stock Motorola firmware)
+- **EMUI variant** — installs to `/system/etc/media/` (Huawei EMUI path)
+- `service.sh` extended per variant to also write directly to variant-specific paths on KernelSU + SUSFS setups
+
+---
+
 ## [1.2.0] - 2026-03-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ To fix this, a custom script was written that processes every single frame indiv
 
 ## Download — Which ZIP do I need?
 
-Three variants are available in [**Releases**](https://github.com/docbt/GeminiBootAnimation/releases/latest):
+Five variants are available in [**Releases**](https://github.com/docbt/GeminiBootAnimation/releases/latest):
 
 | File | For |
 |---|---|
 | `GeminiBootAnimation-standard-*.zip` | **Google Pixel**, stock Android, OnePlus, Realme, most AOSP-based ROMs |
 | `GeminiBootAnimation-MIUI-*.zip` | **Xiaomi** devices running **MIUI** |
 | `GeminiBootAnimation-MTK-*.zip` | Devices with **MediaTek (MTK)** chipsets on stock firmware |
+| `GeminiBootAnimation-Motorola-*.zip` | **Motorola** devices on stock firmware (OEM partition at `/oem/media/`) |
+| `GeminiBootAnimation-EMUI-*.zip` | **Huawei** devices running **EMUI** (`/system/etc/media/`) |
 
 > **Not sure?** Start with the **standard** variant. If the animation doesn't appear after reboot, try the variant matching your chipset or ROM.
 
@@ -72,6 +74,8 @@ Three variants are available in [**Releases**](https://github.com/docbt/GeminiBo
 | standard | `/product/media/` · `/system/media/` |
 | MIUI | `/product/media/` · `/system/media/` · `/system_ext/media/` · `/system/media/theme/` |
 | MTK | `/product/media/` · `/system/media/` · `/custom/media/` |
+| Motorola | `/product/media/` · `/system/media/` · `/oem/media/` |
+| EMUI | `/product/media/` · `/system/media/` · `/system/etc/media/` |
 
 ---
 
@@ -151,7 +155,7 @@ This module installs `bootanimation.zip` to **both** paths for maximum compatibi
 Android checks paths in this priority order:
 
 1. `/apex/com.android.bootanimation/etc/bootanimation.zip` *(Android 10+)*
-2. `/oem/media/bootanimation.zip`
+2. `/oem/media/bootanimation.zip` ← **Motorola variant**
 3. `/product/media/bootanimation.zip` ← **this module (primary)**
 4. `/system/media/bootanimation.zip` ← **this module (fallback)**
 
@@ -174,13 +178,15 @@ Huawei uses a non-standard path and a proprietary rendering pipeline:
 - EMUI: `/system/etc/media/` or `/data/cust/media/`
 - HarmonyOS: proprietary pipeline — standard `bootanimation.zip` replacement is generally **ineffective**
 
-This module is **not compatible** with Huawei/HarmonyOS devices.
+Use the **EMUI variant** for Huawei devices running EMUI — it installs to `/system/etc/media/` in addition to the standard paths.
+
+> **HarmonyOS** is **not supported** — its rendering pipeline is proprietary and does not use `bootanimation.zip`.
 
 ### Motorola
 
 Boot animations on Motorola devices are stored on a dedicated OEM partition at `/oem/media/bootanimation.zip`, which is a separate block device — not `/system/media/`. Replacing the file in `/system/media/` has no effect on stock Motorola firmware.
 
-This module will **likely not work** on stock Motorola firmware.
+Use the **Motorola variant** — it additionally installs to `/oem/media/` so the OEM partition path is covered.
 
 ### Xiaomi MIUI
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build script — generates all GeminiBootAnimation variant zips
-# v1.2: automatic environment detection (Magisk / KernelSU+SUSFS)
+# v1.3: added Motorola (oem/media) and EMUI (system/etc/media) variants
 # Usage: ./build.sh
 set -e
 
@@ -12,9 +12,10 @@ ANIM="system/media/bootanimation.zip"
 ANIM_DARK="system/media/bootanimation-dark.zip"
 
 build_variant() {
-    local NAME="$1"         # e.g. standard
-    local DESC="$2"         # description for module.prop
-    local EXTRA_DIRS="$3"   # space-separated extra magic-mount dirs (relative)
+    local NAME="$1"              # e.g. standard
+    local DESC="$2"              # description for module.prop
+    local EXTRA_DIRS="$3"        # space-separated extra magic-mount dirs (relative)
+    local SERVICE_EXTRA="$4"     # space-separated extra absolute paths for service.sh try_write
 
     local TMPDIR
     TMPDIR=$(mktemp -d)
@@ -76,6 +77,10 @@ try_write() {
 try_write /product/media
 try_write /system/media
 SERVICESH
+
+    for P in $SERVICE_EXTRA; do
+        echo "try_write ${P}" >> "$TMPDIR/service.sh"
+    done
 
     chmod 755 "$TMPDIR/service.sh"
 
@@ -142,16 +147,29 @@ UBEFOOTER
 # ── Variants ──────────────────────────────────────────────────────────────────
 
 build_variant "standard" \
-    "Gemini Boot Animation v1.2 — Standard (Pixel / AOSP / crDroid / OnePlus / Realme)" \
+    "Gemini Boot Animation v1.3 — Standard (Pixel / AOSP / crDroid / OnePlus / Realme)" \
+    "" \
     ""
 
 build_variant "MIUI" \
-    "Gemini Boot Animation v1.2 — Xiaomi MIUI (all MIUI media paths)" \
-    "system_ext/media system/media/theme"
+    "Gemini Boot Animation v1.3 — Xiaomi MIUI (all MIUI media paths)" \
+    "system_ext/media system/media/theme" \
+    ""
 
 build_variant "MTK" \
-    "Gemini Boot Animation v1.2 — MediaTek (custom/media priority path)" \
-    "custom/media"
+    "Gemini Boot Animation v1.3 — MediaTek (custom/media priority path)" \
+    "custom/media" \
+    ""
+
+build_variant "Motorola" \
+    "Gemini Boot Animation v1.3 — Motorola (oem/media partition path)" \
+    "oem/media" \
+    "/oem/media"
+
+build_variant "EMUI" \
+    "Gemini Boot Animation v1.3 — Huawei EMUI (system/etc/media path)" \
+    "system/etc/media" \
+    "/system/etc/media"
 
 echo ""
 echo "Done. Zips in $OUT/:"

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=gemini-bootanimation
 name=Gemini Boot Animation
-version=v1.2
-versionCode=3
+version=v1.3
+versionCode=4
 author=docbt
 description=Original Gemini bootanimation ported from Pixel 10


### PR DESCRIPTION
- Motorola variant: installs to /oem/media/ (OEM partition used by stock Motorola firmware)
- EMUI variant: installs to /system/etc/media/ (Huawei EMUI path)
- build_variant() now accepts 4th param for extra service.sh try_write paths
- service.sh in each variant extended with variant-specific paths for KernelSU+SUSFS setups
- README: download table updated (3 → 5 variants), device notes updated
- CHANGELOG: v1.3.0 entry added
- module.prop: bumped to v1.3 / versionCode 4